### PR TITLE
update: add new match for ULCX's new IRC

### DIFF
--- a/thelounge-sb.user.js
+++ b/thelounge-sb.user.js
@@ -71,6 +71,7 @@
         MATCHERS: [
             'Chatbot',          // ATH
             '&ULCX',            // ULCX
+            '%ULCX',            // ULCX (New IRC)
             '@Willie',          // BHD
             'Bot',              // LST
             '+Mellos',          // HUNO (Discord)


### PR DESCRIPTION
There's a second IRC but the bot has different privileges so the match needs to be updated. 