### PR TITLE
Add DarkPeers, ReelFLiX and HomieHelpDesk

### DIFF
--- a/thelounge-sb.user.js
+++ b/thelounge-sb.user.js
@@ -75,6 +75,7 @@
             '&ULCX',            // ULCX
             '%ULCX',            // ULCX (New IRC)
             '@Willie',          // BHD
+			'@WALL-E',          // RFX
             'Bot',              // LST
             '+Mellos',          // HUNO (Discord)
             /.+?-web/,          // HUNO (Shoutbox)
@@ -146,6 +147,23 @@
             enabled: true,
             handler: function (msg) {
                 const match = msg.text.match(/^\[SB\]\s+([^:]+):\s*(.*)$/);
+                if (!match) return null;
+
+                return {
+                    username: match[1],
+                    modifyContent: true,
+                    prefixToRemove: removeMatchedPrefix(match),
+                    metadata: CONFIG.METADATA
+                };
+            }
+        },
+        {
+            // Format: [Chatbox] Nickname: Message
+            // Used at: RFX
+
+            enabled: true,
+            handler: function (msg) {
+                const match = msg.text.match(/^\[Chatbox\]\s+([^:]+):\s*(.*)$/);
                 if (!match) return null;
 
                 return {

--- a/thelounge-sb.user.js
+++ b/thelounge-sb.user.js
@@ -76,6 +76,7 @@
             '%ULCX',            // ULCX (New IRC)
             '@Willie',          // BHD
 			'@WALL-E',          // RFX
+			'BBot'              // HHD
             'Bot',              // LST
             '+Mellos',          // HUNO (Discord)
             /.+?-web/,          // HUNO (Shoutbox)
@@ -251,7 +252,7 @@
         },
         {
             // Format: [Nickname] Message or [Nickname]: Message
-            // Used at: ATH, DP, ULCX, LST
+            // Used at: ATH, DP, ULCX, HHD, LST
 
             enabled: true,
             handler: function (msg) {

--- a/thelounge-sb.user.js
+++ b/thelounge-sb.user.js
@@ -71,6 +71,7 @@
         // NOTE: A hit from any matcher will run all handlers
         MATCHERS: [
             'Chatbot',          // ATH
+			'&darkpeers',       // DP
             '&ULCX',            // ULCX
             '%ULCX',            // ULCX (New IRC)
             '@Willie',          // BHD
@@ -232,7 +233,7 @@
         },
         {
             // Format: [Nickname] Message or [Nickname]: Message
-            // Used at: ATH, ULCX, LST
+            // Used at: ATH, DP, ULCX, LST
 
             enabled: true,
             handler: function (msg) {

--- a/thelounge-sb.user.js
+++ b/thelounge-sb.user.js
@@ -76,7 +76,7 @@
             '%ULCX',            // ULCX (New IRC)
             '@Willie',          // BHD
 			'@WALL-E',          // RFX
-			'BBot'              // HHD
+			'BBot',             // HHD
             'Bot',              // LST
             '+Mellos',          // HUNO (Discord)
             /.+?-web/,          // HUNO (Shoutbox)


### PR DESCRIPTION
Reelflix (RFX) added using the same coding as BHD however between the username and message there is a weird blank "whitespace?" box that links to the users profile and not sure how to get rid of it and it doesn't appear with every user/message other than that it works. Maybe you might know why it's hapening @spin-drift? 🙂

<img width="227" height="149" alt="Screenshot 2025-09-19 023417" src="https://github.com/user-attachments/assets/e307d925-3b87-406a-b5fe-174982971040" />
<img width="156" height="144" alt="Screenshot 2025-09-19 023438" src="https://github.com/user-attachments/assets/529904d1-6a92-4a53-8fa3-6bf5ebb60c81" />
